### PR TITLE
Use HTTP keep-alive for Ruby PubNub client

### DIFF
--- a/ruby/lib/pubnub.rb
+++ b/ruby/lib/pubnub.rb
@@ -17,6 +17,8 @@ require 'json'
 require 'pp'
 
 class Pubnub
+    MAX_RETRIES = 3
+
     #**
     #* Pubnub
     #*
@@ -206,8 +208,20 @@ class Pubnub
             '%' + ch.unpack('H2')[0].to_s.upcase : URI.encode(ch)
         }.join('') }.join('/')
 
-        response = @connection.get(url).body
+        response = send_with_retries(url, MAX_RETRIES)
         JSON.parse(response)
+    end
+
+    private
+
+    def send_with_retries(url, retries)
+      tries = 0
+      begin
+        @connection.get(url).body
+      rescue
+        tries += 1
+        tries < retries ? retry : raise
+      end
     end
 end
 

--- a/ruby/lib/pubnub.rb
+++ b/ruby/lib/pubnub.rb
@@ -1,5 +1,5 @@
-## www.pubnub.com - PubNub realtime push service in the cloud. 
-## http://www.pubnub.com/blog/ruby-push-api - Ruby Push API Blog 
+## www.pubnub.com - PubNub realtime push service in the cloud.
+## http://www.pubnub.com/blog/ruby-push-api - Ruby Push API Blog
 
 ## PubNub Real Time Push APIs and Notifications Framework
 ## Copyright (c) 2010 Stephen Blum
@@ -12,6 +12,7 @@
 require 'digest/md5'
 require 'open-uri'
 require 'uri'
+require 'net/http'
 require 'json'
 require 'pp'
 
@@ -39,6 +40,9 @@ class Pubnub
         else
             @origin = 'http://'  + @origin
         end
+
+        uri         = URI.parse(@origin)
+        @connection = Net::HTTP.start(uri.host, uri.port)
     end
 
     #**
@@ -197,16 +201,13 @@ class Pubnub
     #*
     def _request(request)
         ## Construct Request URL
-        url = @origin + '/' + request.map{ |bit| bit.split('').map{ |ch|
+        url = '/' + request.map{ |bit| bit.split('').map{ |ch|
             ' ~`!@#$%^&*()+=[]\\{}|;\':",./<>?'.index(ch) ?
             '%' + ch.unpack('H2')[0].to_s.upcase : URI.encode(ch)
         }.join('') }.join('/')
 
-        response = ''
-        open(url) do |f|
-            response = f.read
-        end
-
+        puts "Sending URL: #{url}"
+        response = @connection.get(url).body
         return JSON.parse(response)
     end
 end

--- a/ruby/lib/pubnub.rb
+++ b/ruby/lib/pubnub.rb
@@ -206,9 +206,8 @@ class Pubnub
             '%' + ch.unpack('H2')[0].to_s.upcase : URI.encode(ch)
         }.join('') }.join('/')
 
-        puts "Sending URL: #{url}"
         response = @connection.get(url).body
-        return JSON.parse(response)
+        JSON.parse(response)
     end
 end
 


### PR DESCRIPTION
This pull request implements HTTP keep-alive support with retries. We've found that the latency is significantly reduced when publishing messages since the same connection/session is re-used.
