### PR TITLE
Fixes a bug, replaces & deprecates oddly/mis- named methods, etc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,11 @@
-.settings
-*~
-*.swp
-*.pyc
-*.class
-*.iml
-/flash/*/out
-/android/PubnubAndroidTest/*/gen
-/android/PubnubAndroidTest/*/bin
-/android/PubnubAndroidTest/*/out
+# Xcode noise
+objective-c/**/*.xcworkspace/xcuserdata/*
+objective-c/**/*.xcodeproj/xcuserdata/*
+objective-c/**/*.xcodeproj/project.xcworkspace/*
+*.pbxuser
+*.mode1v3
+*.mode2v3
+
+# OS X & vim noise
 .DS_Store
-node_modules
-.idea
-/csharp/*/PubNub-Messaging*/bin/*
-/csharp/*/PubNub-Messaging*/obj/*
+*.swp

--- a/objective-c/3.3/Pubnub.xcodeproj/project.pbxproj
+++ b/objective-c/3.3/Pubnub.xcodeproj/project.pbxproj
@@ -262,6 +262,7 @@
 		C8FD4D52153D447200D0A418 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Pubnub/Pubnub-Prefix.pch";
 				INFOPLIST_FILE = "Pubnub/Pubnub-Info.plist";
@@ -274,6 +275,7 @@
 		C8FD4D53153D447200D0A418 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Pubnub/Pubnub-Prefix.pch";
 				INFOPLIST_FILE = "Pubnub/Pubnub-Info.plist";

--- a/objective-c/3.3/Pubnub.xcodeproj/project.pbxproj
+++ b/objective-c/3.3/Pubnub.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		6FC5E1CE1603C90300101576 /* CEPubnubDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CEPubnubDelegate.h; sourceTree = "<group>"; };
 		C8FD4D33153D447200D0A418 /* Pubnub.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Pubnub.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C8FD4D37153D447200D0A418 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		C8FD4D39153D447200D0A418 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -37,7 +38,7 @@
 		C8FD4D6B153D469D00D0A418 /* Base64.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Base64.h; sourceTree = "<group>"; };
 		C8FD4D6C153D469D00D0A418 /* Base64.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Base64.m; sourceTree = "<group>"; };
 		C8FD4D6D153D469D00D0A418 /* CEPubnub.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CEPubnub.h; sourceTree = "<group>"; };
-		C8FD4D6E153D469D00D0A418 /* CEPubnub.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CEPubnub.m; sourceTree = "<group>"; };
+		C8FD4D6E153D469D00D0A418 /* CEPubnub.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = CEPubnub.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		C8FD4D6F153D469D00D0A418 /* Cipher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Cipher.h; sourceTree = "<group>"; };
 		C8FD4D70153D469D00D0A418 /* Cipher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Cipher.m; sourceTree = "<group>"; };
 		C8FD4D71153D469D00D0A418 /* Common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Common.h; sourceTree = "<group>"; };
@@ -114,10 +115,11 @@
 		C8FD4D6A153D469D00D0A418 /* PubNub */ = {
 			isa = PBXGroup;
 			children = (
-				C8FD4D6B153D469D00D0A418 /* Base64.h */,
-				C8FD4D6C153D469D00D0A418 /* Base64.m */,
+				6FC5E1CE1603C90300101576 /* CEPubnubDelegate.h */,
 				C8FD4D6D153D469D00D0A418 /* CEPubnub.h */,
 				C8FD4D6E153D469D00D0A418 /* CEPubnub.m */,
+				C8FD4D6B153D469D00D0A418 /* Base64.h */,
+				C8FD4D6C153D469D00D0A418 /* Base64.m */,
 				C8FD4D6F153D469D00D0A418 /* Cipher.h */,
 				C8FD4D70153D469D00D0A418 /* Cipher.m */,
 				C8FD4D71153D469D00D0A418 /* Common.h */,

--- a/objective-c/3.3/Pubnub/PubNub/CEPubnub.h
+++ b/objective-c/3.3/Pubnub/PubNub/CEPubnub.h
@@ -13,92 +13,71 @@
     // limitations under the License.
 
 #import <Foundation/Foundation.h>
+#import "CEPubnubDelegate.h"
 
-@class CEPubnub;
-
-@protocol CEPubnubDelegate <NSObject>
-@optional
-- (void) pubnub:(CEPubnub*)pubnub didSucceedPublishingMessageToChannel:(NSString*)channel withResponce: (id)responce message:(id)message;
-- (void) pubnub:(CEPubnub*)pubnub didFailPublishingMessageToChannel:(NSString*)channel error:(NSString*)error message:(id)message;  // "error" may be nil
-
-    //- (void) pubnub:(PubNub*)pubnub didReceiveMessage:(NSDictionary*)message onChannel:(NSString*)channel;
-
-- (void)pubnub:(CEPubnub *)pubnub subscriptionDidReceiveDictionary:(NSDictionary *)message onChannel:(NSString *)channel;
-- (void)pubnub:(CEPubnub *)pubnub subscriptionDidReceiveArray:(NSArray *)message onChannel:(NSString *)channel;
-- (void)pubnub:(CEPubnub *)pubnub subscriptionDidReceiveString:(NSString *)message onChannel:(NSString *)channel;
-- (void)pubnub:(CEPubnub *)pubnub subscriptionDidFailWithResponse:(NSString *)message onChannel:(NSString *)channel;
-
-- (void) pubnub:(CEPubnub*)pubnub didFetchHistory:(NSArray*)messages forChannel:(NSString*)channel; 
-- (void) pubnub:(CEPubnub*)pubnub didFailFetchHistoryOnChannel:(NSString*)channel withError:(id)error;
-
-- (void) pubnub:(CEPubnub*)pubnub didFetchDetailedHistory:(NSArray*)messages forChannel:(NSString*)channel;
-- (void) pubnub:(CEPubnub*)pubnub didFailFetchDetailedHistoryOnChannel:(NSString*)channel withError:(id)error;
-
-- (void) pubnub:(CEPubnub*)pubnub didReceiveTime:(NSTimeInterval)time;  // "time" will be NAN on failure
-
-- (void) pubnub:(CEPubnub*)pubnub ConnectToChannel:(NSString*)channel ;
-- (void) pubnub:(CEPubnub*)pubnub DisconnectToChannel:(NSString*)channel ;
-- (void) pubnub:(CEPubnub*)pubnub Re_ConnectToChannel:(NSString*)channel ;
-
-- (void)pubnub:(CEPubnub *)pubnub presence:(NSDictionary *)message onChannel:(NSString *)channel;
-
-- (void)pubnub:(CEPubnub *)pubnub here_now:(NSDictionary *)message onChannel:(NSString *)channel;
-@end
-
-    // All operations happen on the main thread
-    // Messages must be JSON compatible
+// All operations happen on the main thread
+// Messages must be JSON compatible
 @interface CEPubnub : NSObject {
 @private
     __unsafe_unretained id<CEPubnubDelegate> _delegate;
-    NSString* _publishKey;
-    NSString* _subscribeKey;
-    NSString* _secretKey;
-    NSString* _host;
-    NSString* _cipherKey;
-    NSString* _uuids;
+    NSString *_publishKey;
+    NSString *_subscribeKey;
+    NSString *_secretKey;
+    NSString *_host;
+    NSString *_cipherKey;
+    NSString *_uuids;
     
     NSMutableSet* _connections;
     NSMutableSet * _subscriptions;
     
     int _tryCount;
 }
-@property(nonatomic, assign) id<CEPubnubDelegate> delegate;
-- (CEPubnub*) initWithSubscribeKey:(NSString*)subscribeKey useSSL:(BOOL)useSSL;
-- (CEPubnub*) initWithPublishKey:(NSString*)publishKey
-                    subscribeKey:(NSString*)subscribeKey
-                       secretKey:(NSString*)secretKey
+
+@property (nonatomic, assign) id<CEPubnubDelegate> delegate;
+
+- (CEPubnub *)initWithSubscribeKey:(NSString *)subscribeKey useSSL:(BOOL)useSSL;
+
+- (CEPubnub *)initWithPublishKey:(NSString *)publishKey
+                    subscribeKey:(NSString *)subscribeKey
+                       secretKey:(NSString *)secretKey
                           useSSL:(BOOL)useSSL;
 
-- (CEPubnub*) initWithPublishKey:(NSString*)publishKey  // May be nil if -publishMessage:toChannel: is never used
-                    subscribeKey:(NSString*)subscribeKey
-                       secretKey:(NSString*)secretKey  // May be nil if -publishMessage:toChannel: is never used
+- (CEPubnub *)initWithPublishKey:(NSString *)publishKey  // May be nil if -publishMessage:toChannel: is never used
+                    subscribeKey:(NSString *)subscribeKey
+                       secretKey:(NSString *)secretKey  // May be nil if -publishMessage:toChannel: is never used
                           useSSL:(BOOL)useSSL
-                       cipherKey:(NSString*)cipherKey  
-                          origin:(NSString*)origin;
+                       cipherKey:(NSString *)cipherKey
+                          origin:(NSString *)origin;
 
-- (CEPubnub*) initWithPublishKey:(NSString*)publishKey
-                    subscribeKey:(NSString*)subscribeKey
-                       secretKey:(NSString*)secretKey
-                       cipherKey:(NSString*)cipherKey
+- (CEPubnub *)initWithPublishKey:(NSString *)publishKey
+                    subscribeKey:(NSString *)subscribeKey
+                       secretKey:(NSString *)secretKey
+                       cipherKey:(NSString *)cipherKey
                           useSSL:(BOOL)useSSL;
 
-- (void) publish:(NSDictionary * )arg1;
-- (void) publish:(NSString * )message onChannel:(NSString *) channel;
-- (void) fetchHistory:(NSDictionary * )arg1;
-- (void) detailedHistory:(NSDictionary * )arg1;
-- (void) unsubscribeFromAllChannels;
-- (void) getTime;
-+ (NSString*) getUUID;
-- (void) subscribe:(NSString*)channel;  // Does nothing if already subscribed
-- (void) unsubscribeFromChannel:(NSString*)channel;  // Does nothing if not subscribed
-- (BOOL) isSubscribedToChannel:(NSString*)channel;
-- (void) here_now:(NSString*)channel;
-- (void) presence:(NSString*)channel;
-@end
++ (NSString *)getUUID;
 
+- (void)publish:(NSDictionary *)arg1;
+- (void)publish:(NSString *)message onChannel:(NSString *)channel;
+- (void)fetchHistory:(NSDictionary *)arg1;
+- (void)detailedHistory:(NSDictionary *)arg1;
+- (void)unsubscribeFromAllChannels;
+- (void)getTime;
+- (void)subscribe:(NSString *)channel;  // Does nothing if already subscribed
+- (void)unsubscribeFromChannel:(NSString *)channel;  // Does nothing if not subscribed
+- (BOOL)isSubscribedToChannel:(NSString *)channel;
+- (void)here_now:(NSString *)channel;
+- (void)presence:(NSString *)channel;
+
+
+@end
 
 @interface ChannelStatus :NSObject
-@property(nonatomic, retain) NSString* channel;
+
+@property(nonatomic, retain) NSString *channel;
 @property(nonatomic, nonatomic) BOOL connected;
 @property(nonatomic, nonatomic) BOOL first;
+
 @end
+
+

--- a/objective-c/3.3/Pubnub/PubNub/CEPubnub.h
+++ b/objective-c/3.3/Pubnub/PubNub/CEPubnub.h
@@ -66,9 +66,10 @@
 - (void)subscribe:(NSString *)channel;  // Does nothing if already subscribed
 - (void)unsubscribeFromChannel:(NSString *)channel;  // Does nothing if not subscribed
 - (BOOL)isSubscribedToChannel:(NSString *)channel;
-- (void)here_now:(NSString *)channel;
+- (void)hereNow:(NSString *)channel;
 - (void)presence:(NSString *)channel;
 
+- (void)here_now:(NSString *)channel __deprecated;
 
 @end
 

--- a/objective-c/3.3/Pubnub/PubNub/CEPubnub.m
+++ b/objective-c/3.3/Pubnub/PubNub/CEPubnub.m
@@ -34,23 +34,23 @@ typedef enum {
 
 @interface PubNubConnection : NSURLConnection {
 @private
-    CEPubnub * _pubNub;
+    CEPubnub *_pubNub;
     Command _command;
-    NSString* _channel;
+    NSString *_channel;
     id _message;
     
     NSHTTPURLResponse* _response;
     NSMutableData* _data;
 }
 @property(nonatomic, readonly) Command command;
-@property(nonatomic, readonly) NSString* channel;
+@property(nonatomic, readonly) NSString *channel;
 @property(nonatomic, readonly) NSData* data;
 @property(nonatomic, readonly) id message;
-- (id) initWithPubNub:(CEPubnub*)pubNub url:(NSURL*)url command:(Command)command channel:(NSString*)channel;
+- (id) initWithPubNub:(CEPubnub *)pubNub url:(NSURL*)url command:(Command)command channel:(NSString *)channel;
 @end
 
 @interface CEPubnub ()
-- (void) connection:(PubNubConnection*)connection didCompleteWithResponse:(id)response;
+- (void)connection:(PubNubConnection*)connection didCompleteWithResponse:(id)response;
 @end
 
 @implementation ChannelStatus
@@ -61,7 +61,7 @@ typedef enum {
 
 @synthesize command=_command, channel=_channel, data=_data, message=_message;
 
-- (id) initWithPubNub:(CEPubnub*)pubNub url:(NSURL*)url command:(Command)command channel:(NSString*)channel {
+- (id) initWithPubNub:(CEPubnub *)pubNub url:(NSURL*)url command:(Command)command channel:(NSString *)channel {
     NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:url
                                                            cachePolicy:NSURLRequestReloadIgnoringCacheData
                                                        timeoutInterval:kConnectionTimeOut];
@@ -78,7 +78,7 @@ typedef enum {
     return self;
 }
 
-- (id) initWithPubNub:(CEPubnub*)pubNub url:(NSURL*)url command:(Command)command channel:(NSString*)channel message:(id)message{
+- (id) initWithPubNub:(CEPubnub *)pubNub url:(NSURL*)url command:(Command)command channel:(NSString *)channel message:(id)message{
     NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:url
                                                            cachePolicy:NSURLRequestReloadIgnoringCacheData
                                                        timeoutInterval:kConnectionTimeOut];
@@ -96,12 +96,12 @@ typedef enum {
     return self;
 }
 
-- (void) connection:(NSURLConnection*)connection didReceiveResponse:(NSURLResponse*)response {
+- (void)connection:(NSURLConnection*)connection didReceiveResponse:(NSURLResponse*)response {
         // DCHECK(_response == nil);
     _response = (NSHTTPURLResponse*)[response copy];
 }
 
-- (void) connection:(NSURLConnection*)connection didReceiveData:(NSData*)data {
+- (void)connection:(NSURLConnection*)connection didReceiveData:(NSData*)data {
     if (_data == nil) {
         _data = [[NSMutableData alloc] initWithData:data];
     } else {
@@ -109,11 +109,11 @@ typedef enum {
     }
 }
 
-- (void) connectionDidFinishLoading:(NSURLConnection*)connection {
+- (void)connectionDidFinishLoading:(NSURLConnection*)connection {
     if (_response.statusCode == 200) {
-            //  NSString* contente = [[_response allHeaderFields] objectForKey:@"Content-Encoding"];
+            //  NSString *contente = [[_response allHeaderFields] objectForKey:@"Content-Encoding"];
             //  NSLog(@"PubNub request returned Content-Encoding : %@", contente);
-        NSString* contentType = [[_response allHeaderFields] objectForKey:@"Content-Type"];
+        NSString *contentType = [[_response allHeaderFields] objectForKey:@"Content-Type"];
         if ([contentType hasPrefix:@"text/javascript"] && [contentType containsString:@"UTF-8"]) {  // Should be [text/javascript; charset="UTF-8"] but is sometimes different on 3G
             NSError* error = nil;
             id result = [NSJSONSerialization JSONObjectWithData:_data options:kNilOptions error:&error];
@@ -158,7 +158,7 @@ typedef enum {
     }
 }
 
-- (void) connection:(NSURLConnection*)connection didFailWithError:(NSError*)error {
+- (void)connection:(NSURLConnection*)connection didFailWithError:(NSError*)error {
     if ([error.domain isEqualToString:NSURLErrorDomain] && (error.code == NSURLErrorNotConnectedToInternet)) {
         NSLog(@"PubNub request failed due to missing Internet connection");
         switch ([self command]) {
@@ -191,23 +191,25 @@ typedef enum {
 
 @synthesize delegate=_delegate;
 
-- (CEPubnub*) initWithSubscribeKey:(NSString*)subscribeKey useSSL:(BOOL)useSSL {
+- (CEPubnub *) initWithSubscribeKey:(NSString *)subscribeKey useSSL:(BOOL)useSSL {
     return [self initWithPublishKey:nil subscribeKey:subscribeKey secretKey:nil useSSL:useSSL cipherKey:nil origin:kDefaultOrigin];
 }
 
-- (CEPubnub*) initWithPublishKey:(NSString*)publishKey
-                    subscribeKey:(NSString*)subscribeKey
-                       secretKey:(NSString*)secretKey
-                          useSSL:(BOOL)useSSL {
+- (CEPubnub *)initWithPublishKey:(NSString *)publishKey
+                    subscribeKey:(NSString *)subscribeKey
+                       secretKey:(NSString *)secretKey
+                          useSSL:(BOOL)useSSL
+{
     return [self initWithPublishKey:publishKey subscribeKey:subscribeKey secretKey:secretKey useSSL:useSSL cipherKey:nil origin:kDefaultOrigin];
 }
 
-- (CEPubnub*) initWithPublishKey:(NSString*)publishKey
-                    subscribeKey:(NSString*)subscribeKey
-                       secretKey:(NSString*)secretKey
+- (CEPubnub *)initWithPublishKey:(NSString *)publishKey
+                    subscribeKey:(NSString *)subscribeKey
+                       secretKey:(NSString *)secretKey
                           useSSL:(BOOL)useSSL
-                       cipherKey:(NSString*)cipherKey  
-                          origin:(NSString*)origin {
+                       cipherKey:(NSString *)cipherKey
+                          origin:(NSString *)origin
+{
     if ((self = [super init])) {
         _publishKey = [publishKey copy];
         _subscribeKey = [subscribeKey copy];
@@ -220,30 +222,31 @@ typedef enum {
     return self;
 }
 
-- (CEPubnub*) initWithPublishKey:(NSString*)publishKey
-                    subscribeKey:(NSString*)subscribeKey
-                       secretKey:(NSString*)secretKey
-                       cipherKey:(NSString*)cipherKey
-                          useSSL:(BOOL)useSSL{
+- (CEPubnub *)initWithPublishKey:(NSString *)publishKey
+                    subscribeKey:(NSString *)subscribeKey
+                       secretKey:(NSString *)secretKey
+                       cipherKey:(NSString *)cipherKey
+                          useSSL:(BOOL)useSSL
+{
     return [self initWithPublishKey:publishKey subscribeKey:subscribeKey secretKey:secretKey useSSL:useSSL cipherKey:cipherKey origin:kDefaultOrigin];
 }
 
-- (void) dealloc {
+- (void)dealloc {
     for (PubNubConnection* connection in _connections) {
         [connection cancel];
     }
     
 }
 
--(NSDictionary*) getEncryptedDictionary:(NSDictionary*)message
+-(NSDictionary* )getEncryptedDictionary:(NSDictionary*)message
 {
     if(_cipherKey != nil)
     {
         NSMutableDictionary* msg = [NSMutableDictionary dictionaryWithCapacity: message.count];
         NSDictionary* disc = (NSDictionary*) message;
-        for (NSString* key in [disc allKeys]) {
-            NSString* val = (NSString*)[disc objectForKey:key];
-            NSString * dec = [CommonFunction AES128EncryptWithKey: _cipherKey Data:val];
+        for (NSString *key in [disc allKeys]) {
+            NSString *val = (NSString *)[disc objectForKey:key];
+            NSString *dec = [CommonFunction AES128EncryptWithKey: _cipherKey Data:val];
             [msg setObject: dec forKey:key];
         }
         
@@ -252,9 +255,9 @@ typedef enum {
     return [NSMutableDictionary dictionaryWithDictionary: message];
 }
 
--(NSString*) getEncryptedString:(NSString*)disc
+-(NSString *)getEncryptedString:(NSString *)disc
 {
-    NSString * returnval;
+    NSString *returnval;
     if(_cipherKey != nil)
     {
         returnval=  [CommonFunction AES128EncryptWithKey:_cipherKey Data:disc];
@@ -265,7 +268,7 @@ typedef enum {
     return returnval;
 }
 
--(NSArray*) getEncryptedArray:(NSArray*)array
+-(NSArray *)getEncryptedArray:(NSArray*)array
 {
     NSMutableArray *messages = [NSMutableArray arrayWithCapacity: 10];
     for (int i=0; i<array.count; i++) {
@@ -282,13 +285,13 @@ typedef enum {
     return messages;
 }
 
-- (void) publish:(NSString * )message onChannel:(NSString *) channel{
+- (void)publish:(NSString *)message onChannel:(NSString *) channel{
     NSDictionary *disc=   [NSDictionary dictionaryWithObjectsAndKeys:channel,@"channel",message,@"message", nil];
     [self publish:disc];
 }
 
-- (void) publish:(NSDictionary * )arg1{
-    NSString * channel = [arg1 objectForKey: @"channel"];
+- (void)publish:(NSDictionary * )arg1{
+    NSString *channel = [arg1 objectForKey: @"channel"];
     id message = [arg1 objectForKey: @"message"];
     if (!channel) {
         NSLog(@"ERROR::Channel name not found.");
@@ -302,21 +305,21 @@ typedef enum {
     
     id msg = nil;
     if ([message isKindOfClass:[NSString class]]) {
-        msg = [self getEncryptedString:(NSString*) message];
+        msg = [self getEncryptedString:(NSString *) message];
     } else if ([message isKindOfClass:[NSArray class]]) {
         msg = [self getEncryptedArray:(NSArray*) message];
     } else if ([message isKindOfClass:[NSDictionary class]]) {
         msg = [self getEncryptedDictionary:(NSDictionary*) message];
     }
     
-    NSString* json = [CommonFunction JSONToString:msg ];
-    NSString* signature;
+    NSString *json = [CommonFunction JSONToString:msg ];
+    NSString *signature;
     if (_secretKey) {
         signature =[CommonFunction HMAC_SHA256withKey:[NSString stringWithFormat:@"%@",_secretKey] Input:[NSString stringWithFormat:@"%@/%@/%@/%@/%@", _publishKey, _subscribeKey, _secretKey, channel, json] ];
     } else {
         signature = @"0";
     }
-    NSString* url = [NSString stringWithFormat:@"%@/publish/%@/%@/%@/%@/0/%@", _host, _publishKey, _subscribeKey, signature,
+    NSString *url = [NSString stringWithFormat:@"%@/publish/%@/%@/%@/%@/0/%@", _host, _publishKey, _subscribeKey, signature,
                      [channel urlEscapedString], [json urlEscapedString]];
     
     PubNubConnection* connection = [[PubNubConnection alloc] initWithPubNub:self
@@ -328,9 +331,9 @@ typedef enum {
     [_connections addObject:connection];
 }
 
-- (void) _resubscribeToChannel:(NSString*)channel timeToken:(NSString*)timeToken {
+- (void)_resubscribeToChannel:(NSString *)channel timeToken:(NSString *)timeToken {
     
-    NSString* url = [NSString stringWithFormat:@"%@/subscribe/%@/%@/0/%@/?uuid=%@", _host, _subscribeKey, [channel urlEscapedString], timeToken,_uuids];
+    NSString *url = [NSString stringWithFormat:@"%@/subscribe/%@/%@/0/%@/?uuid=%@", _host, _subscribeKey, [channel urlEscapedString], timeToken,_uuids];
     PubNubConnection* connection = [[PubNubConnection alloc] initWithPubNub:self
                                                                         url:[NSURL URLWithString:url]
                                                                     command:kCommand_ReceiveMessage
@@ -339,7 +342,7 @@ typedef enum {
     
 }
 
-- (void) _resubscribeToChannel:(NSString*)channel {
+- (void)_resubscribeToChannel:(NSString *)channel {
         // Ensure Single Connection
     if (_subscriptions && [_subscriptions count] > 0) {
         
@@ -373,14 +376,14 @@ typedef enum {
     [self _resubscribeToChannel:channel timeToken:kInitialTimeToken];
 }
 
-- (void) subscribe:(NSString*)channel {
+- (void)subscribe:(NSString *)channel {
     if (![self isSubscribedToChannel:channel]) {
         [self _resubscribeToChannel:channel];
         NSLog(@"Did subscribe to PubNub channel \"%@\"", channel);
     }
 }
 
-- (void) here_now:(NSString*)channel {
+- (void)here_now:(NSString *)channel {
     if(channel == nil || channel ==@"")
     {
         NSLog(@"Missing channel");
@@ -388,17 +391,16 @@ typedef enum {
     }
     
     
-    NSString* url = [NSString stringWithFormat:@"%@/v2/presence/sub_key/%@/channel/%@", _host, _subscribeKey, [channel urlEscapedString]];
+    NSString *url = [NSString stringWithFormat:@"%@/v2/presence/sub_key/%@/channel/%@", _host, _subscribeKey, [channel urlEscapedString]];
     
     PubNubConnection* connection = [[PubNubConnection alloc] initWithPubNub:self
                                                                         url:[NSURL URLWithString:url]
                                                                     command:kCommand_Here_Now
                                                                     channel:channel];
     [_connections addObject:connection];
-    
 }
 
-- (void) presence:(NSString*)channel
+- (void)presence:(NSString *)channel
 {
     if(channel == nil || channel ==@"")
     {
@@ -408,7 +410,7 @@ typedef enum {
     [self subscribe:[NSString stringWithFormat:@"%@-pnpres", channel]];
 }
 
-- (void) unsubscribeFromChannel:(NSString*)channel {
+- (void)unsubscribeFromChannel:(NSString *)channel {
     for (PubNubConnection* connection in [_connections copy]) {
         if ((connection.command == kCommand_ReceiveMessage) && (!channel || [connection.channel isEqualToString:channel])) {
             NSLog(@"Did unsubscribe from PubNub channel \"%@\"", connection.channel);
@@ -432,7 +434,7 @@ typedef enum {
     [NSObject cancelPreviousPerformRequestsWithTarget:self];
 }
 
-- (BOOL) isSubscribedToChannel:(NSString*)channel {
+- (BOOL)isSubscribedToChannel:(NSString *)channel {
     for (PubNubConnection* connection in _connections) {
         if ((connection.command == kCommand_ReceiveMessage) && [connection.channel isEqualToString:channel]) {
             if ([_delegate respondsToSelector:@selector(pubnub:subscriptionDidFailWithResponse:onChannel:)]) {
@@ -451,19 +453,19 @@ typedef enum {
     return NO;
 }
 
-- (void) unsubscribeFromAllChannels {
+- (void)unsubscribeFromAllChannels {
     [self unsubscribeFromChannel:nil];
 }
 
-- (void) fetchHistory:(NSUInteger)limit forChannel:(NSString*)channel {
+- (void)fetchHistory:(NSUInteger)limit forChannel:(NSString *)channel {
     NSNumber * aWrappedInt = [NSNumber numberWithInteger:limit];
     NSDictionary* disc=  [NSDictionary dictionaryWithObjectsAndKeys: aWrappedInt,@"limit", channel,@"channel",nil];
     [self fetchHistory:disc];
 }
 
-- (void) fetchHistory:(NSDictionary * )arg1 {
+- (void)fetchHistory:(NSDictionary * )arg1 {
     int limit;
-    NSString* channel;
+    NSString *channel;
     if (![arg1 objectForKey:@"limit"])
     {
         NSLog(@"ERROR::limit not found.");
@@ -486,7 +488,7 @@ typedef enum {
     if (limit > kMaxHistorySize) {
         NSLog(@"PubNub history too large: %i", limit);
     }
-    NSString* url = [NSString stringWithFormat:@"%@/history/%@/%@/0/%i", _host, _subscribeKey, [channel urlEscapedString], limit];
+    NSString *url = [NSString stringWithFormat:@"%@/history/%@/%@/0/%i", _host, _subscribeKey, [channel urlEscapedString], limit];
     PubNubConnection* connection = [[PubNubConnection alloc] initWithPubNub:self
                                                                         url:[NSURL URLWithString:url]
                                                                     command:kCommand_FetchHistory
@@ -495,9 +497,9 @@ typedef enum {
 }
 
 
-- (void) detailedHistory:(NSDictionary * )arg1 {
+- (void)detailedHistory:(NSDictionary * )arg1 {
    
-    NSString* channel;
+    NSString *channel;
     
     
     if (![arg1 objectForKey:@"channel"])
@@ -550,7 +552,7 @@ typedef enum {
         [parameters insertString:@"?" atIndex:0 ];
     }
          
-    NSString* url = [NSString stringWithFormat:@"%@/v2/history/sub-key/%@/channel/%@%@", _host, _subscribeKey, [channel urlEscapedString],[parameters description]];
+    NSString *url = [NSString stringWithFormat:@"%@/v2/history/sub-key/%@/channel/%@%@", _host, _subscribeKey, [channel urlEscapedString],[parameters description]];
     PubNubConnection* connection = [[PubNubConnection alloc] initWithPubNub:self
                                                                         url:[NSURL URLWithString:url]
                                                                     command:kCommand_FetchDetailHistory
@@ -558,10 +560,8 @@ typedef enum {
     [_connections addObject:connection];
 }
 
-
-
-- (void) getTime {
-    NSString* url = [NSString stringWithFormat:@"%@/time/0", _host];
+- (void)getTime {
+    NSString *url = [NSString stringWithFormat:@"%@/time/0", _host];
     PubNubConnection* connection = [[PubNubConnection alloc] initWithPubNub:self
                                                                         url:[NSURL URLWithString:url]
                                                                     command:kCommand_GetTime
@@ -569,10 +569,10 @@ typedef enum {
     [_connections addObject:connection];
 }
 
-NSDecimalNumber* time_token = 0;
+NSDecimalNumber *time_token = 0;
 
-- (void) getTime1 {
-    NSString* url = [NSString stringWithFormat:@"%@/time/0", _host]; 
+- (void)getTime1 {
+    NSString *url = [NSString stringWithFormat:@"%@/time/0", _host]; 
     NSURLRequest * urlRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:url] cachePolicy:NSURLRequestReloadIgnoringCacheData timeoutInterval:1.0];
     
     [NSURLConnection
@@ -603,19 +603,19 @@ NSDecimalNumber* time_token = 0;
      }];
 }
 
-+ (NSString *) getUUID
++ (NSString *)getUUID
 {
     return [CommonFunction generateUuidString];
 }
 
--(NSDictionary*) getDecryptedDictionary:(NSDictionary*)message
+- (NSDictionary *)getDecryptedDictionary:(NSDictionary*)message
 {
     if(_cipherKey != nil)
     {
         NSMutableDictionary *msg = [NSMutableDictionary dictionaryWithCapacity: message.count];
-        for (NSString* key in [message allKeys]) {
-            NSString* val = (NSString*) [message objectForKey: key];
-            NSString* dec = [CommonFunction AES128DecryptWithKey: _cipherKey Data: val];
+        for (NSString *key in [message allKeys]) {
+            NSString *val = (NSString *) [message objectForKey: key];
+            NSString *dec = [CommonFunction AES128DecryptWithKey: _cipherKey Data: val];
             [msg setObject: dec forKey: key];
         }
         return msg;
@@ -624,9 +624,9 @@ NSDecimalNumber* time_token = 0;
     return [NSMutableDictionary dictionaryWithDictionary: message];
 }
 
--(NSString*) getDecryptedString:(NSString*)disc
+- (NSString *)getDecryptedString:(NSString *)disc
 {
-    NSString * returnval;
+    NSString *returnval;
     if(_cipherKey != nil)
     {
         returnval=  [CommonFunction AES128DecryptWithKey:_cipherKey Data:disc];
@@ -637,7 +637,7 @@ NSDecimalNumber* time_token = 0;
     return returnval;
 }
 
--(NSArray*) getDecryptedArray:(NSArray*)array
+- (NSArray *)getDecryptedArray:(NSArray*)array
 {   
     NSMutableArray *messages = [NSMutableArray arrayWithCapacity: array.count];
     for (int i=0; i < array.count; i++) {
@@ -653,11 +653,11 @@ NSDecimalNumber* time_token = 0;
     return messages;
 }
 
-- (void) connection:(PubNubConnection*)connection didCompleteWithResponse:(id)response  {
+- (void)connection:(PubNubConnection*)connection didCompleteWithResponse:(id)response  {
     switch (connection.command) {
         case kCommand_SendMessage: {
             BOOL success = NO;
-            NSString* error = nil;
+            NSString *error = nil;
             NSArray *array=nil;
             if(response)
             {
@@ -699,7 +699,7 @@ NSDecimalNumber* time_token = 0;
             if ([connection.channel hasSuffix:@"-pnpres"]) {
                 isPresence=YES;
             }
-            NSString* timeToken = @"0";
+            NSString *timeToken = @"0";
             if(!isPresence)
             {
 
@@ -786,7 +786,7 @@ NSDecimalNumber* time_token = 0;
                     for (id message in [response objectAtIndex:0]) {
                         if ([message isKindOfClass:[NSDictionary class]]) {
                             if ([_delegate respondsToSelector:@selector(pubnub:presence:onChannel:)]) {
-                                NSString* channel = [connection.channel stringByReplacingOccurrencesOfString:@"-pnpres"                                                                     withString:@""];
+                                NSString *channel = [connection.channel stringByReplacingOccurrencesOfString:@"-pnpres"                                                                     withString:@""];
                                 [_delegate pubnub:self presence:message onChannel:channel];
                             }
                         }
@@ -829,7 +829,7 @@ NSDecimalNumber* time_token = 0;
                         NSArray * arr=[self getDecryptedArray:(NSArray *)message];
                         [mainArray addObject:arr];
                     }else if ([message isKindOfClass:[NSString class]]) {
-                        NSString * str=[self getDecryptedString:(NSString *)message];
+                        NSString *str=[self getDecryptedString:(NSString *)message];
                         [mainArray addObject:str];
                     }
                 }
@@ -869,7 +869,7 @@ NSDecimalNumber* time_token = 0;
                         NSArray * arr=[self getDecryptedArray:(NSArray *)message];
                         [mainArray addObject:arr];
                     }else if ([message isKindOfClass:[NSString class]]) {
-                        NSString * str=[self getDecryptedString:(NSString *)message];
+                        NSString *str=[self getDecryptedString:(NSString *)message];
                         [mainArray addObject:str];
                     }
                 }
@@ -920,4 +920,5 @@ NSDecimalNumber* time_token = 0;
     }
     [_connections removeObject: connection];
 }
+
 @end

--- a/objective-c/3.3/Pubnub/PubNub/CEPubnub.m
+++ b/objective-c/3.3/Pubnub/PubNub/CEPubnub.m
@@ -772,12 +772,12 @@ NSDecimalNumber* time_token = 0;
                                 [_delegate pubnub:self subscriptionDidReceiveArray:arr onChannel:connection.channel];
                             }
                         }else if ([message isKindOfClass:[NSString class]]) {
-                            if ([_delegate respondsToSelector:@selector(pubnub:subscriptionDidReceiveArray:onChannel:)]) {
+                            if ([_delegate respondsToSelector:@selector(pubnub:subscriptionDidReceiveString:onChannel:)]) {
                                 NSString * str=[self getDecryptedString:(NSString *)message];
                                 [_delegate pubnub:self subscriptionDidReceiveString:str onChannel:connection.channel];
                             }
                         }else {
-                            if ([_delegate respondsToSelector:@selector(pubnub:subscriptionDidFailWithResponse:onChannel:onChannel:)]) {
+                            if ([_delegate respondsToSelector:@selector(pubnub:subscriptionDidFailWithResponse:onChannel:)]) {
                                 [_delegate pubnub:self subscriptionDidFailWithResponse:message onChannel:connection.channel];
                             }
                         }

--- a/objective-c/3.3/Pubnub/PubNub/CEPubnubDelegate.h
+++ b/objective-c/3.3/Pubnub/PubNub/CEPubnubDelegate.h
@@ -5,10 +5,9 @@
 @protocol CEPubnubDelegate <NSObject>
 
 @optional
-
 - (void)pubnub:(CEPubnub *)pubnub
     didSucceedPublishingMessageToChannel:(NSString *)channel
-    withResponce:(id)responce
+    withResponse:(id)response
     message:(id)message;
 
 - (void)pubnub:(CEPubnub *)pubnub
@@ -29,11 +28,19 @@
 
 - (void)pubnub:(CEPubnub *)pubnub didReceiveTime:(NSTimeInterval)time;  // "time" will be NAN on failure
 
-- (void)pubnub:(CEPubnub *)pubnub ConnectToChannel:(NSString *)channel;
-- (void)pubnub:(CEPubnub *)pubnub DisconnectToChannel:(NSString *)channel;
-- (void)pubnub:(CEPubnub *)pubnub Re_ConnectToChannel:(NSString *)channel;
+- (void)pubnub:(CEPubnub *)pubnub connectToChannel:(NSString *)channel;
+- (void)pubnub:(CEPubnub *)pubnub disconnectFromChannel:(NSString *)channel;
+- (void)pubnub:(CEPubnub *)pubnub reconnectToChannel:(NSString *)channel;
 
 - (void)pubnub:(CEPubnub *)pubnub presence:(NSDictionary *)message onChannel:(NSString *)channel;
-- (void)pubnub:(CEPubnub *)pubnub here_now:(NSDictionary *)message onChannel:(NSString *)channel;
+- (void)pubnub:(CEPubnub *)pubnub hereNow:(NSDictionary *)message onChannel:(NSString *)channel;
+
+// **** deprecated methods ****
+
+- (void)pubnub:(CEPubnub *)pubnub didSucceedPublishingMessageToChannel:(NSString *)channel withResponce: (id)responce message:(id)message __deprecated;
+- (void)pubnub:(CEPubnub *)pubnub ConnectToChannel:(NSString *)channel __deprecated;
+- (void)pubnub:(CEPubnub *)pubnub DisconnectToChannel:(NSString *)channel __deprecated;
+- (void)pubnub:(CEPubnub *)pubnub Re_ConnectToChannel:(NSString *)channel __deprecated;
+- (void)pubnub:(CEPubnub *)pubnub here_now:(NSDictionary *)message onChannel:(NSString *)channel __deprecated;
 
 @end

--- a/objective-c/3.3/Pubnub/PubNub/CEPubnubDelegate.h
+++ b/objective-c/3.3/Pubnub/PubNub/CEPubnubDelegate.h
@@ -1,0 +1,39 @@
+#import <Foundation/Foundation.h>
+
+@class CEPubnub;
+
+@protocol CEPubnubDelegate <NSObject>
+
+@optional
+
+- (void)pubnub:(CEPubnub *)pubnub
+    didSucceedPublishingMessageToChannel:(NSString *)channel
+    withResponce:(id)responce
+    message:(id)message;
+
+- (void)pubnub:(CEPubnub *)pubnub
+    didFailPublishingMessageToChannel:(NSString *)channel
+    error:(NSString *)error
+    message:(id)message;  // "error" may be nil
+
+- (void)pubnub:(CEPubnub *)pubnub subscriptionDidReceiveDictionary:(NSDictionary *)message onChannel:(NSString *)channel;
+- (void)pubnub:(CEPubnub *)pubnub subscriptionDidReceiveArray:(NSArray *)message onChannel:(NSString *)channel;
+- (void)pubnub:(CEPubnub *)pubnub subscriptionDidReceiveString:(NSString *)message onChannel:(NSString *)channel;
+- (void)pubnub:(CEPubnub *)pubnub subscriptionDidFailWithResponse:(NSString *)message onChannel:(NSString *)channel;
+
+- (void)pubnub:(CEPubnub *)pubnub didFetchHistory:(NSArray *)messages forChannel:(NSString *)channel;
+- (void)pubnub:(CEPubnub *)pubnub didFailFetchHistoryOnChannel:(NSString *)channel withError:(id)error;
+
+- (void)pubnub:(CEPubnub *)pubnub didFetchDetailedHistory:(NSArray *)messages forChannel:(NSString *)channel;
+- (void)pubnub:(CEPubnub *)pubnub didFailFetchDetailedHistoryOnChannel:(NSString *)channel withError:(id)error;
+
+- (void)pubnub:(CEPubnub *)pubnub didReceiveTime:(NSTimeInterval)time;  // "time" will be NAN on failure
+
+- (void)pubnub:(CEPubnub *)pubnub ConnectToChannel:(NSString *)channel;
+- (void)pubnub:(CEPubnub *)pubnub DisconnectToChannel:(NSString *)channel;
+- (void)pubnub:(CEPubnub *)pubnub Re_ConnectToChannel:(NSString *)channel;
+
+- (void)pubnub:(CEPubnub *)pubnub presence:(NSDictionary *)message onChannel:(NSString *)channel;
+- (void)pubnub:(CEPubnub *)pubnub here_now:(NSDictionary *)message onChannel:(NSString *)channel;
+
+@end

--- a/objective-c/3.3/Pubnub/iPhoneTest.h
+++ b/objective-c/3.3/Pubnub/iPhoneTest.h
@@ -7,7 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "CEPubnub.h"
+#import "CEPubnubDelegate.h"
 
 @interface iPhoneTest : UIViewController<CEPubnubDelegate>
 - (IBAction)StringPublish:(id)sender;

--- a/objective-c/3.3/Pubnub/iPhoneTest.m
+++ b/objective-c/3.3/Pubnub/iPhoneTest.m
@@ -7,7 +7,7 @@
     //
 
 #import "iPhoneTest.h"
-
+#import "CEPubnub.h"
 
 @interface iPhoneTest ()
 
@@ -49,7 +49,7 @@ CEPubnub *pubnub;
 - (IBAction)StringPublish:(id)sender {
     
 	NSLog(@"-----------PUBLISH STRING----------------");
-    NSString * text=@"Hello World";
+    NSString *text=@"Hello World";
     [pubnub publish:[NSDictionary dictionaryWithObjectsAndKeys:@"hello_world",@"channel",text,@"message", nil]];
 }
 
@@ -94,7 +94,7 @@ CEPubnub *pubnub;
 }
 
 - (IBAction)Here_Now:(id)sender {
-     [pubnub here_now: @"hello_world"];  
+     [pubnub here_now: @"hello_world"];
 }
 
 - (IBAction)Presence:(id)sender {
@@ -132,8 +132,6 @@ CEPubnub *pubnub_user_supplied_options ;
 CEPubnub *pubnub_high_security ;
 CEPubnub *_pubnubtemp;
 
-
-
 - (void)unitTest
 {
     pubnub_high_security = [[CEPubnub alloc] initWithPublishKey:@"pub-c-a30c030e-9f9c-408d-be89-d70b336ca7a0" subscribeKey:@"sub-c-387c90f3-c018-11e1-98c9-a5220e0555fd" secretKey:@"sec-c-MTliNDE0NTAtYjY4Ni00MDRkLTllYTItNDhiZGE0N2JlYzBl" cipherKey:@"YWxzamRmbVjFaa05HVnGFqZHM3NXRBS73jxmhVMkjiwVVXV1d5UrXR1JLSkZFRrWVd4emFtUm1iR0TFpUZvbiBoYXMgYmVlbxWkhNaF3uUi8kM0YkJTEVlZYVFjBYijFkWFIxSkxTa1pGUjd874hjklaTFpUwRVuIFNob3VsZCB5UwRkxUR1J6YVhlQWaV1ZkNGVH32mDkdho3pqtRnRVbTFpUjBaeGUgYXNrZWQtZFoKjda40ZWlyYWl1eXU4RkNtdmNub2l1dHE2TTA1jd84jkdJTbFJXYkZwWlZtRnKkWVrSRhhWbFpZVmFzc2RkZmTFpUpGa1dGSXhTa3hUYTFwR1Vpkm9yIGluZm9ybWFNfdsWQdSiiYXNWVXRSblJWYlRGcFVqQmFlRmRyYUU0MFpXbHlZV2wxZVhVNFJrTnR51YjJsMWRIRTJUW91ciBpbmZvcm1hdGliBzdWJtaXR0ZWQb3UZSBhIHJlc3BvbnNlLCB3ZWxsIHJlVEExWdHVybiB0am0aW9uIb24gYXMgd2UgcG9zc2libHkgY2FuLuhcFe24ldWVnsdSaTFpU3hVUjFKNllWaFdhRmxZUWpCaQo34gcmVxdWlGFzIHNveqQl83snBfVl3" useSSL:false];
@@ -154,7 +152,7 @@ CEPubnub *_pubnubtemp;
     [_pubnubtemp setDelegate:[del getDelegate] ];
     
     
-    for (NSString* channel in many_channels) {
+    for (NSString *channel in many_channels) {
         [_pubnubtemp subscribe:channel];
         [NSThread sleepForTimeInterval:5];
 
@@ -164,105 +162,123 @@ CEPubnub *_pubnubtemp;
     //========================================================================
 #pragma mark -
 #pragma mark CEPubnubDelegate stuff
-    - (void) pubnub:(CEPubnub*)pubnub didSucceedPublishingMessageToChannel:(NSString*)channel withResponce:(id)responce message:(id)message
-    {
-        NSLog(@"Sent message to PubNub channel \"%@\"  \n%@ \nSent Message:%@", channel,responce,message);   
-    }
-    - (void) pubnub:(CEPubnub*)pubnub didFailPublishingMessageToChannel:(NSString*)channel error:(NSString*)error message:(id)message// "error" may be nil
-    {
-        NSLog(@"Publishing Error   %@ \nFor Sent Message   %@",error,message);
-    }
-    
-	- (void) pubnub:(CEPubnub*)pubnub subscriptionDidFailWithResponse:(NSString *)message onChannel:(NSString *)channel
-	{
-    	NSLog(@"Subscription Error:  %@",message);
-	}
 
-	- (void) pubnub:(CEPubnub*)pubnub subscriptionDidReceiveDictionary:(NSDictionary *)message onChannel:(NSString *)channel{
-        [txt setText:[NSString stringWithFormat:@"sub on channel (dict) : %@ - received:\n %@", channel, message]];
-        NSLog(@"Subscribe   %@",message);
-        NSDictionary* disc=(NSDictionary*)message;
-        for (NSString* key in [disc allKeys]) {
-            NSString* val=(NSString*)[disc objectForKey:key];
-            NSLog(@"%@-->   %@",key,val);
-        }
+- (void)pubnub:(CEPubnub *)pubnub
+    didSucceedPublishingMessageToChannel:(NSString *)channel
+    withResponce:(id)responce
+    message:(id)message
+{
+    NSLog(@"Sent message to PubNub channel \"%@\"  \n%@ \nSent Message:%@", channel, responce,  message);
+}
+
+// "error" may be nil
+- (void)pubnub:(CEPubnub *)pubnub
+    didFailPublishingMessageToChannel:(NSString *)channel
+    error:(NSString *)error
+    message:(id)message
+{
+    NSLog(@"Publishing Error   %@ \nFor Sent Message   %@", error, message);
+}
+
+
+- (void)pubnub:(CEPubnub *)pubnub
+    subscriptionDidFailWithResponse:(NSString *)message
+    onChannel:(NSString *)channel
+{
+    NSLog(@"Subscription Error:  %@",message);
+}
+
+- (void)pubnub:(CEPubnub *)pubnub
+    subscriptionDidReceiveDictionary:(NSDictionary *)message
+    onChannel:(NSString *)channel
+{
+    [txt setText:[NSString stringWithFormat:@"sub on channel (dict) : %@ - received:\n %@", channel, message]];
+    NSLog(@"Subscribe   %@",message);
+    NSDictionary* disc=(NSDictionary*)message;
+    for (NSString *key in [disc allKeys]) {
+        NSString *val=(NSString *)[disc objectForKey:key];
+        NSLog(@"%@-->   %@",key,val);
     }
-    
-    - (void) pubnub:(CEPubnub*)pubnub subscriptionDidReceiveArray:(NSArray *)message onChannel:(NSString *)channel{
-       
-        NSLog(@"Subscribe   %@",message);
-        [txt setText:[NSString stringWithFormat:@"sub on channel (dict) : %@ - received\n: %@", channel, message]];
+}
+
+- (void)pubnub:(CEPubnub *)pubnub subscriptionDidReceiveArray:(NSArray *)message onChannel:(NSString *)channel
+{
+    NSLog(@"Subscribe   %@",message);
+    [txt setText:[NSString stringWithFormat:@"sub on channel (dict) : %@ - received\n: %@", channel, message]];
+}
+
+- (void)pubnub:(CEPubnub *)pubnub subscriptionDidReceiveString:(NSString *)message onChannel:(NSString *)channel
+{
+    NSLog(@"Subscribe   %@",message);
+    [txt setText:[NSString stringWithFormat:@"sub on channel (dict) : %@ - received:\n %@", channel, message]];
+}
+
+- (void)pubnub:(CEPubnub *)pubnub didFetchHistory:(NSArray *)messages forChannel:(NSString *)channel{
+    int i=0;
+
+    NSMutableString *histry=  [NSMutableString stringWithString: @""];
+    for (NSString *object in messages) {
+        NSLog(@"%d \n%@",i,object);
+        [histry appendString:[NSString stringWithFormat:@" %i\n%@",i,object]];
+        i++;
     }
-    - (void) pubnub:(CEPubnub*)pubnub subscriptionDidReceiveString:(NSString *)message onChannel:(NSString *)channel{
-       
-        NSLog(@"Subscribe   %@",message);
-        [txt setText:[NSString stringWithFormat:@"sub on channel (dict) : %@ - received:\n %@", channel, message]];
-    }   
-    
-    - (void) pubnub:(CEPubnub*)pubnub didFetchHistory:(NSArray*)messages forChannel:(NSString*)channel{
-        int i=0;
-      
-        NSMutableString *histry=  [NSMutableString stringWithString: @""];
-        for (NSString * object in messages) {
-            NSLog(@"%d \n%@",i,object);
-            [histry appendString:[NSString stringWithFormat:@" %i\n%@",i,object]];
-            i++;
-        } 
-        [txt setText:[NSString stringWithFormat:@"History on channel (dict) : %@ - received:\n %@", channel, histry]];
-      
-    }
-    -(void) pubnub:(CEPubnub *)pubnub didFailFetchHistoryOnChannel:(NSString *)channel withError:(id)error
-    {
-        [txt setText:[NSString stringWithFormat:@"Fail to fetch history on channel  : %@ with Error: %@", channel,error]];
-    }
-    
-    -(void) pubnub:(CEPubnub *)pubnub didFetchDetailedHistory:(NSArray *)messages forChannel:(NSString *)channel
-    {
-        NSMutableString *histry=  [NSMutableString stringWithString: @""];
-        for (id object in messages) {
+    [txt setText:[NSString stringWithFormat:@"History on channel (dict) : %@ - received:\n %@", channel, histry]];
+
+}
+-(void) pubnub:(CEPubnub *)pubnub didFailFetchHistoryOnChannel:(NSString *)channel withError:(id)error
+{
+    [txt setText:[NSString stringWithFormat:@"Fail to fetch history on channel  : %@ with Error: %@", channel,error]];
+}
+
+-(void) pubnub:(CEPubnub *)pubnub didFetchDetailedHistory:(NSArray *)messages forChannel:(NSString *)channel
+{
+    NSMutableString *histry=  [NSMutableString stringWithString: @""];
+    for (id object in messages) {
         [histry appendString:[NSString stringWithFormat:@" %@\n",object]];
-        }
-        [txt setText:[NSString stringWithFormat:@"History on channel (dict) : %@ - received:\n %@", channel, histry]];
     }
-    -(void) pubnub:(CEPubnub *)pubnub didFailFetchDetailedHistoryOnChannel:(NSString *)channel withError:(id)error
-    {
-        [txt setText:[NSString stringWithFormat:@"Fail to fetch  Detailed history on channel  : %@ with Error: %@", channel,error]];
-    }   
+    [txt setText:[NSString stringWithFormat:@"History on channel (dict) : %@ - received:\n %@", channel, histry]];
+}
+-(void) pubnub:(CEPubnub *)pubnub didFailFetchDetailedHistoryOnChannel:(NSString *)channel withError:(id)error
+{
+    [txt setText:[NSString stringWithFormat:@"Fail to fetch  Detailed history on channel  : %@ with Error: %@", channel,error]];
+}
 
 
-    - (void) pubnub:(CEPubnub*)pubnub didReceiveTime:(NSTimeInterval)time{
-        NSLog(@"didReceiveTime   %f",time );
-        [txt setText:[NSString stringWithFormat:@"Time  :- received:\n %f", time]];
-    }  
-    
-    - (void) pubnub:(CEPubnub*)pubnub ConnectToChannel:(NSString *)channel{
-        NSLog(@"Connect to Channel:   %@",channel);
-    }  
-    
-    - (void) pubnub:(CEPubnub*)pubnub DisconnectToChannel:(NSString *)channel{
-        NSLog(@"Disconnect to Channel:   %@",channel);
-    } 
-    - (void) pubnub:(CEPubnub*)pubnub Re_ConnectToChannel:(NSString *)channel{
-        NSLog(@"Re-Connect to Channel:   %@",channel);
-    } 
+- (void)pubnub:(CEPubnub *)pubnub didReceiveTime:(NSTimeInterval)time{
+    NSLog(@"didReceiveTime   %f",time );
+    [txt setText:[NSString stringWithFormat:@"Time  :- received:\n %f", time]];
+}
 
-    - (void)pubnub:(CEPubnub *)pubnub presence:(NSDictionary *)message onChannel:(NSString *)channel
-    {
-        NSLog(@"channel:%@   \npresence-   %@",channel,message);
-        NSDictionary* disc=(NSDictionary*)message;
-        for (NSString* key in [disc allKeys]) {
-            NSString* val=(NSString*)[disc objectForKey:key];
-            NSLog(@"%@-->   %@",key,val);
-        }
-        [txt setText:[NSString stringWithFormat:@"Presence received on channel %@:-\n %@",channel, message]];
+- (void)pubnub:(CEPubnub *)pubnub ConnectToChannel:(NSString *)channel{
+    NSLog(@"Connect to Channel:   %@",channel);
+}
+
+- (void)pubnub:(CEPubnub *)pubnub DisconnectToChannel:(NSString *)channel{
+    NSLog(@"Disconnect to Channel:   %@",channel);
+}
+
+- (void)pubnub:(CEPubnub *)pubnub Re_ConnectToChannel:(NSString *)channel{
+    NSLog(@"Re-Connect to Channel:   %@",channel);
+}
+
+- (void)pubnub:(CEPubnub *)pubnub presence:(NSDictionary *)message onChannel:(NSString *)channel
+{
+    NSLog(@"channel:%@   \npresence-   %@",channel,message);
+    NSDictionary* disc=(NSDictionary*)message;
+    for (NSString *key in [disc allKeys]) {
+        NSString *val=(NSString *)[disc objectForKey:key];
+        NSLog(@"%@-->   %@",key,val);
     }
+    [txt setText:[NSString stringWithFormat:@"Presence received on channel %@:-\n %@",channel, message]];
+}
 
-- (void) pubnub:(CEPubnub*)pubnub here_now:(NSDictionary *)message onChannel:(NSString *)channel{
+- (void)pubnub:(CEPubnub *)pubnub here_now:(NSDictionary *)message onChannel:(NSString *)channel
+{
     [txt setText:[NSString stringWithFormat:@"sub on channel (dict) : %@ - received:\n %@", channel, message]];
     NSLog(@"here_now-   %@",message);
     NSDictionary* disc=(NSDictionary*)message;
-    for (NSString* key in [disc allKeys]) {
-        NSString* val=(NSString*)[disc objectForKey:key];
+    for (NSString *key in [disc allKeys]) {
+        NSString *val=(NSString *)[disc objectForKey:key];
         NSLog(@"%@-->   %@",key,val);
     }
 }
@@ -271,6 +287,7 @@ CEPubnub *_pubnubtemp;
 
 
 @implementation unitTestDelegates
+
 @synthesize delHolder;
 
 -(id)getDelegate
@@ -284,32 +301,33 @@ CEPubnub *_pubnubtemp;
     return self ;
 }
 
--(void)test:(BOOL) state message:(NSString*) message
+-(void)test:(BOOL)state message:(NSString *)message
 {
-    if(state)
-    {
-        NSLog(@"PASS - %@",message);
-    }else {
-        NSLog(@" FAIL - %@",message);
+    if(state) {
+        NSLog(@"PASS - %@", message);
+    } else {
+        NSLog(@" FAIL - %@" ,message);
     }
-    
 }
 
-- (void) pubnub:(CEPubnub*)pubnub didSucceedPublishingMessageToChannel:(NSString*)channel withResponce:(id)responce message:(id)message
+- (void)pubnub:(CEPubnub *)pubnub
+    didSucceedPublishingMessageToChannel:(NSString *)channel
+    withResponce:(id)responce
+    message:(id)message
 {
     [self test:YES message:[NSString stringWithFormat:@"Publish of channel:%@",channel]];
-    
     
     NSNumber *sent = (NSNumber*) [status objectForKey:@"sent"];
     [status removeObjectForKey:@"sent"];
     [status setObject:[NSNumber numberWithInt:sent.intValue +1] forKey:@"sent"];
     
 }
-- (void) pubnub:(CEPubnub*)pubnub didFailPublishingMessageToChannel:(NSString*)channel error:(NSString*)error message:(id)message
+- (void)pubnub:(CEPubnub *)pubnub
+    didFailPublishingMessageToChannel:(NSString *)channel error:(NSString *)error message:(id)message
 {
     [self test:NO message:[NSString stringWithFormat:@"Publish of channel:%@",channel]];
 }
-- (void) pubnub:(CEPubnub*)pubnub subscriptionDidReceiveDictionary:(NSDictionary *)message onChannel:(NSString *)channel{
+- (void)pubnub:(CEPubnub *)pubnub subscriptionDidReceiveDictionary:(NSDictionary *)message onChannel:(NSString *)channel{
     
     NSNumber *sent = (NSNumber*) [status objectForKey:@"sent"];
     NSNumber *received = (NSNumber*) [status objectForKey:@"received"];
@@ -322,22 +340,24 @@ CEPubnub *_pubnubtemp;
     [_pubnubtemp fetchHistory:[NSDictionary dictionaryWithObjectsAndKeys: aWrappedInt,@"limit", channel,@"channel",nil]];
 }
 
-- (void) pubnub:(CEPubnub*)pubnub subscriptionDidReceiveArray:(NSArray *)message onChannel:(NSString *)channel{
+- (void)pubnub:(CEPubnub *)pubnub subscriptionDidReceiveArray:(NSArray *)message onChannel:(NSString *)channel{
     NSLog(@"Subscribe   %@",message);
 }
-- (void) pubnub:(CEPubnub*)pubnub subscriptionDidReceiveString:(NSString *)message onChannel:(NSString *)channel{
+- (void)pubnub:(CEPubnub *)pubnub subscriptionDidReceiveString:(NSString *)message onChannel:(NSString *)channel{
     NSLog(@"Subscribe   %@",message);
 }   
 
-- (void) pubnub:(CEPubnub*)pubnub didFetchHistory:(NSArray*)messages forChannel:(NSString*)channel{
+- (void)pubnub:(CEPubnub *)pubnub didFetchHistory:(NSArray *)messages forChannel:(NSString *)channel{
     [self test:YES message:[NSString stringWithFormat:@"Fetch Histry of channel:%@",channel]];
 }
 
-- (void) pubnub:(CEPubnub*)pubnub didReceiveTime:(NSTimeInterval)time{
+- (void)pubnub:(CEPubnub *)pubnub didReceiveTime:(NSTimeInterval)time
+{
     NSLog(@"didReceiveTime   %f",time );
 }  
 
-- (void) pubnub:(CEPubnub*)pubnub ConnectToChannel:(NSString *)channel{
+- (void)pubnub:(CEPubnub *)pubnub ConnectToChannel:(NSString *)channel
+{
     NSLog(@"Connect to Channel:   %@",channel);
     NSNumber *connections = (NSNumber*) [status objectForKey:@"connections"];
     [status removeObjectForKey:@"connections"];
@@ -345,12 +365,14 @@ CEPubnub *_pubnubtemp;
     [_pubnubtemp publish:[NSDictionary dictionaryWithObjectsAndKeys:channel,@"channel",[NSDictionary dictionaryWithObjectsAndKeys:@"X-code->ÇÈ°∂@#$%^&*()!",@"Editer",@"Objective-c",@"Language", nil],@"message", nil]];
 }  
 
-- (void) pubnub:(CEPubnub*)pubnub DisconnectToChannel:(NSString *)channel{
+- (void)pubnub:(CEPubnub *)pubnub DisconnectToChannel:(NSString *)channel
+{
     NSLog(@"Disconnect to Channel:   %@",channel);
 } 
-- (void) pubnub:(CEPubnub*)pubnub Re_ConnectToChannel:(NSString *)channel{
+
+- (void)pubnub:(CEPubnub *)pubnub Re_ConnectToChannel:(NSString *)channel
+{
     NSLog(@"Re-Connect to Channel:   %@",channel);
-} 
+}
+
 @end
-
-

--- a/objective-c/3.3/Pubnub/iPhoneTest.m
+++ b/objective-c/3.3/Pubnub/iPhoneTest.m
@@ -94,7 +94,7 @@ CEPubnub *pubnub;
 }
 
 - (IBAction)Here_Now:(id)sender {
-     [pubnub here_now: @"hello_world"];
+     [pubnub hereNow: @"hello_world"];
 }
 
 - (IBAction)Presence:(id)sender {
@@ -165,10 +165,10 @@ CEPubnub *_pubnubtemp;
 
 - (void)pubnub:(CEPubnub *)pubnub
     didSucceedPublishingMessageToChannel:(NSString *)channel
-    withResponce:(id)responce
+    withResponse:(id)response
     message:(id)message
 {
-    NSLog(@"Sent message to PubNub channel \"%@\"  \n%@ \nSent Message:%@", channel, responce,  message);
+    NSLog(@"Sent message to PubNub channel \"%@\"  \n%@ \nSent Message:%@", channel, response,  message);
 }
 
 // "error" may be nil
@@ -249,15 +249,15 @@ CEPubnub *_pubnubtemp;
     [txt setText:[NSString stringWithFormat:@"Time  :- received:\n %f", time]];
 }
 
-- (void)pubnub:(CEPubnub *)pubnub ConnectToChannel:(NSString *)channel{
+- (void)pubnub:(CEPubnub *)pubnub connectToChannel:(NSString *)channel{
     NSLog(@"Connect to Channel:   %@",channel);
 }
 
-- (void)pubnub:(CEPubnub *)pubnub DisconnectToChannel:(NSString *)channel{
+- (void)pubnub:(CEPubnub *)pubnub disconnectFromChannel:(NSString *)channel{
     NSLog(@"Disconnect to Channel:   %@",channel);
 }
 
-- (void)pubnub:(CEPubnub *)pubnub Re_ConnectToChannel:(NSString *)channel{
+- (void)pubnub:(CEPubnub *)pubnub reconnectToChannel:(NSString *)channel{
     NSLog(@"Re-Connect to Channel:   %@",channel);
 }
 
@@ -272,7 +272,7 @@ CEPubnub *_pubnubtemp;
     [txt setText:[NSString stringWithFormat:@"Presence received on channel %@:-\n %@",channel, message]];
 }
 
-- (void)pubnub:(CEPubnub *)pubnub here_now:(NSDictionary *)message onChannel:(NSString *)channel
+- (void)pubnub:(CEPubnub *)pubnub hereNow:(NSDictionary *)message onChannel:(NSString *)channel
 {
     [txt setText:[NSString stringWithFormat:@"sub on channel (dict) : %@ - received:\n %@", channel, message]];
     NSLog(@"here_now-   %@",message);
@@ -312,7 +312,7 @@ CEPubnub *_pubnubtemp;
 
 - (void)pubnub:(CEPubnub *)pubnub
     didSucceedPublishingMessageToChannel:(NSString *)channel
-    withResponce:(id)responce
+    withResponse:(id)response
     message:(id)message
 {
     [self test:YES message:[NSString stringWithFormat:@"Publish of channel:%@",channel]];
@@ -356,7 +356,7 @@ CEPubnub *_pubnubtemp;
     NSLog(@"didReceiveTime   %f",time );
 }  
 
-- (void)pubnub:(CEPubnub *)pubnub ConnectToChannel:(NSString *)channel
+- (void)pubnub:(CEPubnub *)pubnub connectToChannel:(NSString *)channel
 {
     NSLog(@"Connect to Channel:   %@",channel);
     NSNumber *connections = (NSNumber*) [status objectForKey:@"connections"];
@@ -365,12 +365,12 @@ CEPubnub *_pubnubtemp;
     [_pubnubtemp publish:[NSDictionary dictionaryWithObjectsAndKeys:channel,@"channel",[NSDictionary dictionaryWithObjectsAndKeys:@"X-code->ÇÈ°∂@#$%^&*()!",@"Editer",@"Objective-c",@"Language", nil],@"message", nil]];
 }  
 
-- (void)pubnub:(CEPubnub *)pubnub DisconnectToChannel:(NSString *)channel
+- (void)pubnub:(CEPubnub *)pubnub disconnectFromChannel:(NSString *)channel
 {
     NSLog(@"Disconnect to Channel:   %@",channel);
 } 
 
-- (void)pubnub:(CEPubnub *)pubnub Re_ConnectToChannel:(NSString *)channel
+- (void)pubnub:(CEPubnub *)pubnub reconnectToChannel:(NSString *)channel
 {
     NSLog(@"Re-Connect to Channel:   %@",channel);
 }


### PR DESCRIPTION
- fixes a bug related to mismatched/misnamed selectors
- breaks CEPubnubDelegate into own file
- replaces some oddly/mis- named API methods, but keeps old ones & marks them as deprecated
- refactors complicated/long method -[CEPubnub connection:didCompleteWithResponse:]
